### PR TITLE
Outdated link in pre commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,8 @@ repos:
       - id: mypy
         exclude: ^docs/conf.py
 
-  - repo: https://gitlab.com/yaq/yaq-traits
-    rev: v2022.3.0
+  - repo: https://github.com/yaq-project/yaq-traits
+    rev: v2022.11.0
     hooks:
       - id: yaq-traits-check
       - id: yaq-traits-compose


### PR DESCRIPTION
psst... maybe merge yaq-project/yaqd-cookiecutter-python#11 to prevent this in the future...